### PR TITLE
Don't rebuild pipenv for most code changes

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -23,12 +23,16 @@ RUN pip install pipenv
 RUN useradd -ms /bin/bash user
 USER user:user
 
-# Copy code
-COPY . /app
 WORKDIR /app
+COPY Pipfile .
+COPY Pipfile.lock .
+
 
 # Install python dependencies
 RUN pipenv --python /usr/local/bin/python install --dev
+
+# Copy code
+COPY . .
 
 EXPOSE 5000
 ENV FLASK_APP flock_server


### PR DESCRIPTION
Previously the Dockerfile for flock would do a copy of the whole directory before it installed the
pipenv. Since docker checks whether anything in a COPY has changed when deciding if it needs to
rebuild later stages, a change to any file in flock would cause the app's whole pipenv to be
recreated. This process takes some time. This commit changes the Dockerfile to first copy just the
pipfile file and pipfile.lock, then install the dependencies, and *then* copy the rest of the flock
files. This allows docker to cache the pipenv step in all cases except when the pipfile has been
changed.