### PR TITLE
Add notification summaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     environment:
       IMAGE_NAME: micahflee/flock-server
     docker:
-      - image: circleci/python:3.7.4-buster
+      - image: circleci/python:3.8-buster
 
 jobs:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: "kibana:7.3.0"
+    image: "kibana:7.6.2"
     environment:
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
     ports:
@@ -30,7 +30,7 @@ services:
       - elasticsearch
 
   elasticsearch:
-    image: "elasticsearch:7.3.0"
+    image: "elasticsearch:7.6.2"
     environment:
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
       - discovery.type=single-node

--- a/src/flock_server/api.py
+++ b/src/flock_server/api.py
@@ -219,11 +219,17 @@ def create_api_app(test_config=None):
             elif len(notification_docs[key]) > 1:
                 added_count = 0
                 removed_count = 0
+                other_count = 0
                 for doc in notification_docs[key]:
-                    if doc["action"] == "added":
-                        added_count += 1
-                    elif doc["action"] == "removed":
-                        removed_count += 1
+                    if "action" in doc:
+                        if doc["action"] == "added":
+                            added_count += 1
+                        elif doc["action"] == "removed":
+                            removed_count += 1
+                        else:
+                            other_count += 1
+                    else:
+                        other_count += 1
 
                 doc = notification_docs[key][0]
                 keybase_notifications.add(
@@ -234,6 +240,7 @@ def create_api_app(test_config=None):
                         "name": doc["user_name"],
                         "added_count": added_count,
                         "removed_count": removed_count,
+                        "other_count": other_count,
                     },
                 )
 

--- a/src/flock_server/api.py
+++ b/src/flock_server/api.py
@@ -2,6 +2,7 @@ import json
 import secrets
 from datetime import datetime
 from functools import wraps
+from collections import defaultdict
 
 from flask import Flask, request
 from elasticsearch_dsl import Index, Search
@@ -190,7 +191,7 @@ def create_api_app(test_config=None):
         docs_by_type = {}
 
         # Add data to ElasticSearch
-        notification_docs = {}
+        notification_docs = defaultdict(list)
         for doc in docs:
             # Convert 'unixTime' to '@timestamp'
             if "unixTime" in doc:
@@ -209,8 +210,6 @@ def create_api_app(test_config=None):
         # Figure out what notifications to send
         for doc in docs:
             if "name" in doc and doc["name"] in notification_names:
-                if doc["name"] not in notification_docs:
-                    notification_docs[doc["name"]] = []
                 notification_docs[doc["name"]].append(doc)
 
         # Send notifications

--- a/src/flock_server/api.py
+++ b/src/flock_server/api.py
@@ -213,14 +213,14 @@ def create_api_app(test_config=None):
                 notification_docs[doc["name"]].append(doc)
 
         # Send notifications
-        for key in notification_docs:
-            if len(notification_docs[key]) == 1:
-                keybase_notifications.add(key, notification_docs[key][0])
-            elif len(notification_docs[key]) > 1:
+        for key, value in notification_docs.items():
+            if len(value) == 1:
+                keybase_notifications.add(key, value[0])
+            elif len(value) > 1:
                 added_count = 0
                 removed_count = 0
                 other_count = 0
-                for doc in notification_docs[key]:
+                for doc in value:
                     if "action" in doc:
                         if doc["action"] == "added":
                             added_count += 1
@@ -231,7 +231,7 @@ def create_api_app(test_config=None):
                     else:
                         other_count += 1
 
-                doc = notification_docs[key][0]
+                doc = value[0]
                 keybase_notifications.add(
                     key,
                     {

--- a/src/flock_server/api.py
+++ b/src/flock_server/api.py
@@ -231,13 +231,12 @@ def create_api_app(test_config=None):
                     else:
                         other_count += 1
 
-                doc = value[0]
                 keybase_notifications.add(
                     key,
                     {
                         "type": "summary",
-                        "username": doc["username"],
-                        "name": doc["user_name"],
+                        "username": request.authorization["username"],
+                        "name": user.name,
                         "added_count": added_count,
                         "removed_count": removed_count,
                         "other_count": other_count,

--- a/src/flock_server/keybase_notifications.py
+++ b/src/flock_server/keybase_notifications.py
@@ -175,11 +175,11 @@ class KeybaseNotifications:
 
                 message = f"- Computer: **{name}** (`{username}`)"
                 if added_count > 0:
-                    message += "\n- **{added_count}** added"
+                    message += f"\n- **{added_count}** added"
                 if removed_count > 0:
-                    message += "\n- **{removed_count}** removed"
+                    message += f"\n- **{removed_count}** removed"
                 if other_count > 0:
-                    message += "\n- **{other_count}** unknown action"
+                    message += f"\n- **{other_count}** unknown action"
             else:
                 # Display the details of a single change
                 username = details_obj["hostIdentifier"]

--- a/src/flock_server/keybase_notifications.py
+++ b/src/flock_server/keybase_notifications.py
@@ -171,8 +171,15 @@ class KeybaseNotifications:
                 name = details_obj["name"]
                 added_count = details_obj["added_count"]
                 removed_count = details_obj["removed_count"]
+                other_count = details_obj["other_count"]
 
-                message = f"- Computer: **{name}** (`{username}`)\n- **{added_count}** added\n- **{removed_count}** removed"
+                message = f"- Computer: **{name}** (`{username}`)"
+                if added_count > 0:
+                    message += "\n- **{added_count}** added"
+                if removed_count > 0:
+                    message += "\n- **{removed_count}** removed"
+                if other_count > 0:
+                    message += "\n- **{other_count}** unknown action"
             else:
                 # Display the details of a single change
                 username = details_obj["hostIdentifier"]

--- a/src/flock_server/keybase_notifications.py
+++ b/src/flock_server/keybase_notifications.py
@@ -149,13 +149,13 @@ class KeybaseNotifications:
                 notification_settings[notification] = False
                 self._save_settings(notification_settings)
 
-    def add(self, notification, osquery_result):
-        details = json.dumps(osquery_result, indent=2)
+    def add(self, notification, details):
+        details_obj = json.dumps(details, indent=2)
         if self._is_enabled(notification):
             # Create a new keybase notification
             keybase_notification = KeybaseNotification(
                 notification_type=notification,
-                details=details,
+                details=details_obj,
                 delivered=False,
                 created_at=datetime.now(),
             )
@@ -165,13 +165,23 @@ class KeybaseNotifications:
         details_obj = json.loads(details)
         if self.notifications[notification]["type"] == "osquery":
             # osquery notifications
-            username = details_obj["hostIdentifier"]
-            name = details_obj["user_name"]
-            action = details_obj["action"]
-            time = details_obj["calendarTime"]
-            columns = json.dumps(details_obj["columns"], indent=2)
+            if "type" in details_obj and details_obj["type"] == "summary":
+                # Display a summary of how many of this type of change
+                username = details_obj["username"]
+                name = details_obj["name"]
+                added_count = details_obj["added_count"]
+                removed_count = details_obj["removed_count"]
 
-            message = f"- Computer affected: **{name}** (`{username}`)\n- Date: {time}\n- Action: {action}\n```\n{columns}```"
+                message = f"- Computer: **{name}** (`{username}`)\n- **{added_count}** added\n- **{removed_count}** removed"
+            else:
+                # Display the details of a single change
+                username = details_obj["hostIdentifier"]
+                name = details_obj["user_name"]
+                action = details_obj["action"]
+                time = details_obj["calendarTime"]
+                columns = json.dumps(details_obj["columns"], indent=2)
+
+                message = f"- Computer: **{name}** (`{username}`)\n- Date: {time}\n- Action: {action}\n```\n{columns}```"
 
         else:
             # user and flock notifications

--- a/tests.yml
+++ b/tests.yml
@@ -9,7 +9,7 @@ services:
       - test-elasticsearch
 
   test-elasticsearch:
-    image: "elasticsearch:7.3.0"
+    image: "elasticsearch:7.6.2"
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
When an agent submits data to the server, instead of sending a keybase notification for each individual submission, if a submission has more than one piece of data, this sends a summary. For example, for the `firefox_addons` twig, if a single Firefox add-on is changed, it sends something like this:

![Screenshot from 2020-04-13 15-36-26](https://user-images.githubusercontent.com/156128/79167749-08407180-7d9d-11ea-9e2e-8bc2d2fcb735.png)

But if multiple Firefox add-ons change, it sends a summary like this:

![Screenshot from 2020-04-13 15-36-40](https://user-images.githubusercontent.com/156128/79167760-11314300-7d9d-11ea-861e-d801b0a3b047.png)

This should fix the problem where an agent makes a large submission and then Keybase spends hours posting all the notifications.